### PR TITLE
Remove /api prefix from 'api' service requests

### DIFF
--- a/tests/test_root.py
+++ b/tests/test_root.py
@@ -12,7 +12,7 @@ def imageproxy_response(image_path):
     image_filename = path.basename(image_path)
     recipe_id, extension = path.splitext(image_filename)
 
-    metadata_uri = f'{API_URL}/api/recipes/{recipe_id}'
+    metadata_uri = f'{API_URL}/recipes/{recipe_id}'
     image_uri = 'http://example.org/image.png'
     proxy_uri = f'{IMAGEPROXY_URL}/192,png/{image_uri}'
 

--- a/web/app.py
+++ b/web/app.py
@@ -29,7 +29,7 @@ def recipe(image_filename):
     recipe_id, extension = path.splitext(image_filename)
 
     recipe = requests.get(
-        url=f'http://backend-service/api/recipes/{recipe_id}',
+        url=f'http://api-service/recipes/{recipe_id}/view',
         proxies={}
     )
     try:
@@ -37,7 +37,7 @@ def recipe(image_filename):
     except Exception:
         return abort(404)
 
-    image_src = recipe.json().get('image_src')
+    image_src = recipe.json()['results'][0].get('image_src')
     image = requests.get(
         url=f'http://imageproxy/192,png/{image_src}',
         proxies={}


### PR DESCRIPTION
### Briefly summarize the changes
1. Remove the `/api` prefix from `api` service request paths

### How have the changes been tested?
1. Unit test coverage exercises the updated paths

**List any issues that this change relates to**
Relates to openculinary/infrastructure#23